### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,6 +1,7 @@
 {
     "perl" : "6.*",
     "name" : "Native::LibC",
+    "license" : "BSL-1.0",
     "version" : "*",
     "description" : "The C standard library [work in progress]",
     "author" : "cygx <cygx@cpan.org>",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license